### PR TITLE
Grass subprocess change

### DIFF
--- a/mower/_main.py
+++ b/mower/_main.py
@@ -89,7 +89,7 @@ class GrassSession():
         except OSError:
             os.mkdir(self.gisdb)
 
-        createcmd = "{0} -c {1} -e {2}".format(
+        createcmd = "{0} -c {1} -e {2} -text".format(
             self.grassbin,
             self.location_seed, 
             self.location_path) 


### PR DESCRIPTION
Currently Grass waits for user input from the command line before running the selected module. This PR fixes that by adding -text flag to the subprocess command so that grass treats the command as text input.
